### PR TITLE
Make monthpicker fully controlled by it's parent

### DIFF
--- a/src/Month.js
+++ b/src/Month.js
@@ -21,11 +21,6 @@ const Month = styled.div`
     outline: none;
   }
 
-  ${props => !props.selected && props.focussed && css`
-    border: 1px solid ${getPrimaryColor};
-    background-color: ${getHoverColor};
-  `}
-
   ${props => props.selected && css`
     border: 1px solid #d3d3d37a;
   `};
@@ -40,20 +35,6 @@ const Month = styled.div`
   justify-content: center;
   align-items: center;
   flex: 0 0 33.33%;
-
-  ${props => props.focussed && !props.selected && css`
-    &:nth-child(3n) {
-      border-right: 1px solid ${getSecondaryColor};
-    }
-
-    &:nth-child(3n+1) {
-      border-left: 1px solid ${getSecondaryColor};
-    }
-
-    &:nth-last-child(-n+3) {
-      border-bottom: 1px solid ${getSecondaryColor};
-    }
-  `}
 
   border-bottom-right-radius: ${props => props.index === 11 && '4px'};
   border-bottom-left-radius: ${props => props.index === 9 && '4px'};

--- a/src/Monthpicker.js
+++ b/src/Monthpicker.js
@@ -47,9 +47,8 @@ class MonthPicker extends React.Component {
     primaryColor: '#27718c',
     secondaryColor: 'white',
     locale: 'de',
-    initialYear: currentYear,
     month: getMonth(currentDate),
-    year: currentYear
+    year: currentYear,
   }
 
   static propTypes = {
@@ -66,7 +65,6 @@ class MonthPicker extends React.Component {
     month: PropTypes.number.isRequired,
     year: PropTypes.number.isRequired,
     format: PropTypes.string,
-    initialYear: PropTypes.number.isRequired,
     onBlur: PropTypes.func,
     onFocus: PropTypes.func,
     onChange: PropTypes.func.isRequired,
@@ -78,19 +76,8 @@ class MonthPicker extends React.Component {
     dialogClassName: PropTypes.string
   }
 
-  // Lifecycle methods
-  constructor(props) {
-    super(props)
-
-    const { initialYear, month, year } = props
-
-    const focussedDate = new Date(year, month - 1)
-
-    this.state = {
-      focussedDate,
-      year: initialYear,
-      open: false,
-    }
+  state = {
+    open: false,
   }
 
   componentDidMount () {
@@ -111,7 +98,7 @@ class MonthPicker extends React.Component {
 
   handleMonthChange = month => event => {
     event.persist()
-    const date = new Date(this.state.year, month)
+    const date = new Date(this.props.year, month)
 
     this.changeValue(date, event)
   }
@@ -129,10 +116,12 @@ class MonthPicker extends React.Component {
   }
 
   handleKeyDown = event => {
-    const { focussedDate, year } = this.state
+    const { open } = this.state
+    const { year, month } = this.props
 
-    const focussedYear = getYear(focussedDate)
-    const matchesCurrentYear = focussedYear === year
+    if (!open) return
+
+    const currentDate = new Date(year, month - 1)
 
     const firstMonthOfSelectedYear = new Date(year, 0)
 
@@ -140,48 +129,33 @@ class MonthPicker extends React.Component {
       case 'ArrowLeft': {
         event.preventDefault()
 
-        const nextFocussedDate = matchesCurrentYear ? subMonths(focussedDate, 1) : firstMonthOfSelectedYear
-
-        if (getYear(nextFocussedDate) < year) this.previousYear()
-
-        return this.setFocussedMonth(nextFocussedDate)
+        const nextDate = subMonths(currentDate, 1)
+        return this.changeValue(nextDate, event)
       }
 
       case 'ArrowRight': {
         event.preventDefault()
 
-        const nextFocussedDate = matchesCurrentYear ? addMonths(focussedDate, 1) : firstMonthOfSelectedYear
-
-        if (getYear(nextFocussedDate) > year) this.nextYear()
-
-        return this.setFocussedMonth(nextFocussedDate)
+        const nextDate = addMonths(currentDate, 1)
+        return this.changeValue(nextDate, event)
       }
 
       case 'ArrowUp': {
         event.preventDefault()
 
-        const nextFocussedDate = matchesCurrentYear ? subMonths(focussedDate, 3) : firstMonthOfSelectedYear
-
-        if (getYear(nextFocussedDate) < year) this.previousYear()
-
-        return this.setFocussedMonth(nextFocussedDate)
+        const nextDate = subMonths(currentDate, 3)
+        return this.changeValue(nextDate, event)
       }
 
       case 'ArrowDown': {
         event.preventDefault()
 
-        const nextFocussedDate = matchesCurrentYear ? addMonths(focussedDate, 3) : firstMonthOfSelectedYear
-
-        if (getYear(nextFocussedDate) > year) this.nextYear()
-
-        return this.setFocussedMonth(nextFocussedDate)
+        const nextDate = addMonths(currentDate, 3)
+        return this.changeValue(nextDate, event)
       }
 
       case 'Enter': {
-        event.preventDefault()
-        event.persist()
-
-        if (focussedDate) return this.changeValue(focussedDate, event)
+        this.close()
       }
 
       default: {
@@ -191,52 +165,46 @@ class MonthPicker extends React.Component {
   }
 
   // Other functions
-  nextYear = () => this.setState(({ year }) => {
-    const { allowedYears } = this.props
+  nextYear = () => {
+    const { allowedYears, year, month } = this.props
 
     if (Array.isArray(allowedYears)) {
       const sortedYears = allowedYears.sort((a,b) => a - b)
       const currentIndex = sortedYears.indexOf(year)
 
-      if (currentIndex < sortedYears.length - 1) return { year: sortedYears[currentIndex + 1] }
+      if (currentIndex < sortedYears.length - 1) {
+        return this.changeValue(new Date(sortedYears[currentIndex + 1], month - 1))
+      }
     }
 
     const nextYear = year + 1
 
     if (this.isAllowedYear(nextYear)) {
-      return { year: nextYear }
+      return this.changeValue(new Date(nextYear, month - 1))
     }
+  }
 
-    return null
-  })
-
-  previousYear = () => this.setState(({ year }) => {
-    const { allowedYears } = this.props
+  previousYear = () => {
+    const { allowedYears, year, month } = this.props
 
     if (Array.isArray(allowedYears)) {
       const sortedYears = allowedYears.sort((a,b) => a - b)
       const currentIndex = sortedYears.indexOf(year)
 
-      if (currentIndex > 0) return { year: sortedYears[currentIndex - 1] }
+      if (currentIndex > 0) {
+        return this.changeValue(new Date(sortedYears[currentIndex - 1], month - 1))
+      }
     }
 
     const previousYear = year - 1
 
     if (this.isAllowedYear(previousYear)) {
-      return { year: previousYear }
+      return this.changeValue(new Date(previousYear, month - 1))
     }
-
-    return null
-  })
+  }
 
   toggleOpen = () => {
     this.setState(({ open }) => ({ open: !open }))
-  }
-
-  setFocussedMonth = date => {
-    if (this.isAllowedYear(getYear(date))) {
-      this.setState({ focussedDate: date })
-    }
   }
 
   close = event => {
@@ -261,10 +229,6 @@ class MonthPicker extends React.Component {
       : { month: getMonth(date) + 1, year: getYear(date) }
 
     if (onChange) onChange(formattedDate, event)
-
-    this.setFocussedMonth(date)
-
-    this.close(event)
   }
 
   isAllowedYear = year => {
@@ -291,13 +255,9 @@ class MonthPicker extends React.Component {
   // Render functions
   renderMonths = () => {
     const { month, year, locale } = this.props
-    const { year: selectedYear, focussedDate } = this.state
 
     const monthNameFormatter = Intl.DateTimeFormat(locale, { month: 'short' })
     const formatDate = currentDate
-
-    const focussedMonth = getMonth(focussedDate)
-    const focussedYear = getYear(focussedDate)
 
     const months = []
 
@@ -305,12 +265,10 @@ class MonthPicker extends React.Component {
       formatDate.setMonth(index)
       const monthName = monthNameFormatter.format(formatDate)
 
-      const isSelectedMonth = month && selectedYear === year && index === month -1
-      const isFocussedMonth = focussedYear === selectedYear && index === focussedMonth
+      const isSelectedMonth = month && index === month -1
 
       months.push(
         <Month
-          focussed={isFocussedMonth}
           selected={isSelectedMonth}
           key={monthName}
           onClick={this.handleMonthChange(index)}
@@ -326,8 +284,8 @@ class MonthPicker extends React.Component {
   }
 
   render () {
-    const { year, open } = this.state
-    const { className, dialogClassName, children } = this.props
+    const { open } = this.state
+    const { className, dialogClassName, children, year } = this.props
 
     const styleProps = getStyleProps(this.props)
 

--- a/src/__tests__/Monthpicker.spec.js
+++ b/src/__tests__/Monthpicker.spec.js
@@ -16,7 +16,7 @@ describe('<Monthpicker />', () => {
   describe('event handling: ', () => {
     it('opens the overlay when clicking on the child', () => {
       const wrapper = mount(
-        <Monthpicker initialYear={2010} month={1} year={2010} onChange={jest.fn()}>
+        <Monthpicker year={2010} month={1} year={2010} onChange={jest.fn()}>
           <div className='child'>Child</div>
         </Monthpicker>
       )
@@ -30,7 +30,7 @@ describe('<Monthpicker />', () => {
 
     it('closes the overlay when clicking anywhere outside the overlay', () => {
       const wrapper = mount(
-        <Monthpicker initialYear={2010} month={1} year={2010} onChange={jest.fn()}>
+        <Monthpicker year={2010} month={1} year={2010} onChange={jest.fn()}>
           <div className='child'>Child</div>
         </Monthpicker>
       )
@@ -41,74 +41,6 @@ describe('<Monthpicker />', () => {
       child.simulate('click')
 
       expect(wrapper).toMatchSnapshot()
-    })
-
-    it('sets the focussed date to 1 month later when hitting ArrowRight', () => {
-      const initialyFocussedMonth = 1
-      const wrapper = mount(
-        <Monthpicker initialYear={2010} month={initialyFocussedMonth} year={2010} onChange={jest.fn()}>
-          <div className='child'>Child</div>
-        </Monthpicker>
-      )
-
-      const child = wrapper.find('.child').first()
-      child.simulate('click')
-
-      wrapper.simulate('keyDown', { key: 'ArrowRight' })
-
-      const focussedMonth = wrapper.findWhere(node => node.key() === 'M02')
-      expect(focussedMonth).toMatchSnapshot()
-    })
-
-    it('sets the focussed date to 1 month earlier when hitting ArrowLeft', () => {
-      const initialyFocussedMonth = 2
-      const wrapper = mount(
-        <Monthpicker initialYear={2010} month={initialyFocussedMonth} year={2010} onChange={jest.fn()}>
-          <div className='child'>Child</div>
-        </Monthpicker>
-      )
-
-      const child = wrapper.find('.child').first()
-      child.simulate('click')
-
-      wrapper.simulate('keyDown', { key: 'ArrowLeft' })
-
-      const focussedMonth = wrapper.findWhere(node => node.key() === 'M01')
-      expect(focussedMonth).toMatchSnapshot()
-    })
-
-    it('sets the focussed date to 3 month later when hitting ArrowDown', () => {
-      const initialyFocussedMonth = 1
-      const wrapper = mount(
-        <Monthpicker initialYear={2010} month={initialyFocussedMonth} year={2010} onChange={jest.fn()}>
-          <div className='child'>Child</div>
-        </Monthpicker>
-      )
-
-      const child = wrapper.find('.child').first()
-      child.simulate('click')
-
-      wrapper.simulate('keyDown', { key: 'ArrowDown' })
-
-      const focussedMonth = wrapper.findWhere(node => node.key() === 'April')
-      expect(focussedMonth).toMatchSnapshot()
-    })
-
-    it('sets the focussed date to 3 month earlier when hitting ArrowUp', () => {
-      const initialyFocussedMonth = 4
-      const wrapper = mount(
-        <Monthpicker initialYear={2010} month={initialyFocussedMonth} year={2010} onChange={jest.fn()}>
-          <div className='child'>Child</div>
-        </Monthpicker>
-      )
-
-      const child = wrapper.find('.child').first()
-      child.simulate('click')
-
-      wrapper.simulate('keyDown', { key: 'ArrowUp' })
-
-      const focussedMonth = wrapper.findWhere(node => node.key() === 'Januar')
-      expect(focussedMonth).toMatchSnapshot()
     })
   })
 
@@ -190,7 +122,8 @@ describe('<Monthpicker />', () => {
         const wrapper = mount(
           <Monthpicker
             allowedYears={[2017]}
-            initialYear={2018}
+            month={10}
+            year={2018}
             onChange={onChange}
           >
             <div className='child'>Child</div>
@@ -202,7 +135,7 @@ describe('<Monthpicker />', () => {
 
         wrapper.find(ArrowLeft).simulate('click')
 
-        expect(wrapper.find(Year)).toMatchSnapshot()
+        expect(onChange).toHaveBeenCalledWith({ month: 10, year: 2017 }, undefined)
       })
 
       it('does not allow selecting years not in the allowedYears array', () => {
@@ -210,7 +143,7 @@ describe('<Monthpicker />', () => {
         const wrapper = mount(
           <Monthpicker
             allowedYears={[2019]}
-            initialYear={2018}
+            year={2018}
             onChange={onChange}
           >
             <div className='child'>Child</div>
@@ -222,7 +155,7 @@ describe('<Monthpicker />', () => {
 
         wrapper.find(ArrowLeft).simulate('click')
 
-        expect(wrapper.find(Year)).toMatchSnapshot()
+        expect(onChange).not.toHaveBeenCalled()
       })
 
       it('goes to the next allowed year when clicking the next button', () => {
@@ -230,7 +163,8 @@ describe('<Monthpicker />', () => {
         const wrapper = mount(
           <Monthpicker
             allowedYears={[2018, 2020]}
-            initialYear={2018}
+            month={10}
+            year={2018}
             onChange={onChange}
           >
             <div className='child'>Child</div>
@@ -242,7 +176,7 @@ describe('<Monthpicker />', () => {
 
         wrapper.find(ArrowRight).simulate('click')
 
-        expect(wrapper.find(Year)).toMatchSnapshot()
+        expect(onChange).toHaveBeenCalledWith({ month: 10, year: 2020 }, undefined)
       })
 
       it('goes to the previous allowed year when clicking the previous button', () => {
@@ -250,7 +184,8 @@ describe('<Monthpicker />', () => {
         const wrapper = mount(
           <Monthpicker
             allowedYears={[2016, 2018]}
-            initialYear={2018}
+            month={10}
+            year={2018}
             onChange={onChange}
           >
             <div className='child'>Child</div>
@@ -262,7 +197,7 @@ describe('<Monthpicker />', () => {
 
         wrapper.find(ArrowLeft).simulate('click')
 
-        expect(wrapper.find(Year)).toMatchSnapshot()
+        expect(onChange).toHaveBeenCalledWith({ month: 10, year: 2016 }, undefined)
       })
 
       it('goes to the correct year with an unsorted array', () => {
@@ -270,7 +205,8 @@ describe('<Monthpicker />', () => {
         const wrapper = mount(
           <Monthpicker
             allowedYears={[2018, 2016, 2020]}
-            initialYear={2018}
+            month={10}
+            year={2018}
             onChange={onChange}
           >
             <div className='child'>Child</div>
@@ -282,14 +218,14 @@ describe('<Monthpicker />', () => {
 
         wrapper.find(ArrowLeft).simulate('click')
 
-        expect(wrapper.find(Year)).toMatchSnapshot()
+        expect(onChange).toHaveBeenCalledWith({ month: 10, year: 2016 }, undefined)
 
         const arrowRight = wrapper.find(ArrowRight)
 
         arrowRight.simulate('click')
         arrowRight.simulate('click')
 
-        expect(wrapper.find(Year)).toMatchSnapshot()
+        expect(onChange).toHaveBeenCalledWith({ month: 10, year: 2020 }, undefined)
       })
     })
 
@@ -299,7 +235,8 @@ describe('<Monthpicker />', () => {
         const wrapper = mount(
           <Monthpicker
             allowedYears={{ before: 2019 }}
-            initialYear={2018}
+            month={10}
+            year={2018}
             onChange={onChange}
           >
             <div className='child'>Child</div>
@@ -311,7 +248,7 @@ describe('<Monthpicker />', () => {
 
         wrapper.find(ArrowLeft).simulate('click')
 
-        expect(wrapper.find(Year)).toMatchSnapshot()
+        expect(onChange).toHaveBeenCalledWith({ month: 10, year: 2017 }, undefined)
       })
 
       it('does not allow values after the before key', () => {
@@ -319,7 +256,7 @@ describe('<Monthpicker />', () => {
         const wrapper = mount(
           <Monthpicker
             allowedYears={{ before: 2019 }}
-            initialYear={2018}
+            year={2018}
             onChange={onChange}
           >
             <div className='child'>Child</div>
@@ -331,7 +268,7 @@ describe('<Monthpicker />', () => {
 
         wrapper.find(ArrowRight).simulate('click')
 
-        expect(wrapper.find(Year)).toMatchSnapshot()
+        expect(onChange).not.toHaveBeenCalled()
       })
 
       it('does allow values after the after key', () => {
@@ -339,7 +276,8 @@ describe('<Monthpicker />', () => {
         const wrapper = mount(
           <Monthpicker
             allowedYears={{ after: 2017 }}
-            initialYear={2018}
+            year={2018}
+            month={10}
             onChange={onChange}
           >
             <div className='child'>Child</div>
@@ -351,7 +289,7 @@ describe('<Monthpicker />', () => {
 
         wrapper.find(ArrowRight).simulate('click')
 
-        expect(wrapper.find(Year)).toMatchSnapshot()
+        expect(onChange).toHaveBeenCalledWith({ month: 10, year: 2019 }, undefined)
       })
 
       it('does not allow values before the after key', () => {
@@ -359,7 +297,7 @@ describe('<Monthpicker />', () => {
         const wrapper = mount(
           <Monthpicker
             allowedYears={{ after: 2017 }}
-            initialYear={2018}
+            year={2018}
             onChange={onChange}
           >
             <div className='child'>Child</div>
@@ -371,7 +309,7 @@ describe('<Monthpicker />', () => {
 
         wrapper.find(ArrowLeft).simulate('click')
 
-        expect(wrapper.find(Year)).toMatchSnapshot()
+        expect(onChange).not.toHaveBeenCalled()
       })
     })
   })

--- a/src/__tests__/__snapshots__/Monthpicker.spec.js.snap
+++ b/src/__tests__/__snapshots__/Monthpicker.spec.js.snap
@@ -217,7 +217,6 @@ exports[`<Monthpicker /> allows specifiyng the primary and secondary colors 1`] 
 
 <MonthPicker
   hoverColor="#d3d3d330"
-  initialYear={2018}
   locale="de"
   month={1}
   onChange={[MockFunction]}
@@ -355,7 +354,6 @@ exports[`<Monthpicker /> allows specifiyng the primary and secondary colors 1`] 
               className="c7"
             >
               <styled.div
-                focussed={true}
                 hoverColor="#d3d3d330"
                 index={0}
                 key="M01"
@@ -373,7 +371,6 @@ exports[`<Monthpicker /> allows specifiyng the primary and secondary colors 1`] 
                 </div>
               </styled.div>
               <styled.div
-                focussed={false}
                 hoverColor="#d3d3d330"
                 index={1}
                 key="M02"
@@ -391,7 +388,6 @@ exports[`<Monthpicker /> allows specifiyng the primary and secondary colors 1`] 
                 </div>
               </styled.div>
               <styled.div
-                focussed={false}
                 hoverColor="#d3d3d330"
                 index={2}
                 key="M03"
@@ -409,7 +405,6 @@ exports[`<Monthpicker /> allows specifiyng the primary and secondary colors 1`] 
                 </div>
               </styled.div>
               <styled.div
-                focussed={false}
                 hoverColor="#d3d3d330"
                 index={3}
                 key="M04"
@@ -427,7 +422,6 @@ exports[`<Monthpicker /> allows specifiyng the primary and secondary colors 1`] 
                 </div>
               </styled.div>
               <styled.div
-                focussed={false}
                 hoverColor="#d3d3d330"
                 index={4}
                 key="M05"
@@ -445,7 +439,6 @@ exports[`<Monthpicker /> allows specifiyng the primary and secondary colors 1`] 
                 </div>
               </styled.div>
               <styled.div
-                focussed={false}
                 hoverColor="#d3d3d330"
                 index={5}
                 key="M06"
@@ -463,7 +456,6 @@ exports[`<Monthpicker /> allows specifiyng the primary and secondary colors 1`] 
                 </div>
               </styled.div>
               <styled.div
-                focussed={false}
                 hoverColor="#d3d3d330"
                 index={6}
                 key="M07"
@@ -481,7 +473,6 @@ exports[`<Monthpicker /> allows specifiyng the primary and secondary colors 1`] 
                 </div>
               </styled.div>
               <styled.div
-                focussed={false}
                 hoverColor="#d3d3d330"
                 index={7}
                 key="M08"
@@ -499,7 +490,6 @@ exports[`<Monthpicker /> allows specifiyng the primary and secondary colors 1`] 
                 </div>
               </styled.div>
               <styled.div
-                focussed={false}
                 hoverColor="#d3d3d330"
                 index={8}
                 key="M09"
@@ -517,7 +507,6 @@ exports[`<Monthpicker /> allows specifiyng the primary and secondary colors 1`] 
                 </div>
               </styled.div>
               <styled.div
-                focussed={false}
                 hoverColor="#d3d3d330"
                 index={9}
                 key="M10"
@@ -535,7 +524,6 @@ exports[`<Monthpicker /> allows specifiyng the primary and secondary colors 1`] 
                 </div>
               </styled.div>
               <styled.div
-                focussed={false}
                 hoverColor="#d3d3d330"
                 index={10}
                 key="M11"
@@ -553,7 +541,6 @@ exports[`<Monthpicker /> allows specifiyng the primary and secondary colors 1`] 
                 </div>
               </styled.div>
               <styled.div
-                focussed={false}
                 hoverColor="#d3d3d330"
                 index={11}
                 key="M12"
@@ -590,7 +577,6 @@ exports[`<Monthpicker /> event handling:  closes the overlay when clicking anywh
 
 <MonthPicker
   hoverColor="#d3d3d330"
-  initialYear={2010}
   locale="de"
   month={1}
   onChange={[MockFunction]}
@@ -839,7 +825,6 @@ exports[`<Monthpicker /> event handling:  opens the overlay when clicking on the
 
 <MonthPicker
   hoverColor="#d3d3d330"
-  initialYear={2010}
   locale="de"
   month={1}
   onChange={[MockFunction]}
@@ -977,7 +962,6 @@ exports[`<Monthpicker /> event handling:  opens the overlay when clicking on the
               className="c7"
             >
               <styled.div
-                focussed={true}
                 hoverColor="#d3d3d330"
                 index={0}
                 key="M01"
@@ -995,7 +979,6 @@ exports[`<Monthpicker /> event handling:  opens the overlay when clicking on the
                 </div>
               </styled.div>
               <styled.div
-                focussed={false}
                 hoverColor="#d3d3d330"
                 index={1}
                 key="M02"
@@ -1013,7 +996,6 @@ exports[`<Monthpicker /> event handling:  opens the overlay when clicking on the
                 </div>
               </styled.div>
               <styled.div
-                focussed={false}
                 hoverColor="#d3d3d330"
                 index={2}
                 key="M03"
@@ -1031,7 +1013,6 @@ exports[`<Monthpicker /> event handling:  opens the overlay when clicking on the
                 </div>
               </styled.div>
               <styled.div
-                focussed={false}
                 hoverColor="#d3d3d330"
                 index={3}
                 key="M04"
@@ -1049,7 +1030,6 @@ exports[`<Monthpicker /> event handling:  opens the overlay when clicking on the
                 </div>
               </styled.div>
               <styled.div
-                focussed={false}
                 hoverColor="#d3d3d330"
                 index={4}
                 key="M05"
@@ -1067,7 +1047,6 @@ exports[`<Monthpicker /> event handling:  opens the overlay when clicking on the
                 </div>
               </styled.div>
               <styled.div
-                focussed={false}
                 hoverColor="#d3d3d330"
                 index={5}
                 key="M06"
@@ -1085,7 +1064,6 @@ exports[`<Monthpicker /> event handling:  opens the overlay when clicking on the
                 </div>
               </styled.div>
               <styled.div
-                focussed={false}
                 hoverColor="#d3d3d330"
                 index={6}
                 key="M07"
@@ -1103,7 +1081,6 @@ exports[`<Monthpicker /> event handling:  opens the overlay when clicking on the
                 </div>
               </styled.div>
               <styled.div
-                focussed={false}
                 hoverColor="#d3d3d330"
                 index={7}
                 key="M08"
@@ -1121,7 +1098,6 @@ exports[`<Monthpicker /> event handling:  opens the overlay when clicking on the
                 </div>
               </styled.div>
               <styled.div
-                focussed={false}
                 hoverColor="#d3d3d330"
                 index={8}
                 key="M09"
@@ -1139,7 +1115,6 @@ exports[`<Monthpicker /> event handling:  opens the overlay when clicking on the
                 </div>
               </styled.div>
               <styled.div
-                focussed={false}
                 hoverColor="#d3d3d330"
                 index={9}
                 key="M10"
@@ -1157,7 +1132,6 @@ exports[`<Monthpicker /> event handling:  opens the overlay when clicking on the
                 </div>
               </styled.div>
               <styled.div
-                focussed={false}
                 hoverColor="#d3d3d330"
                 index={10}
                 key="M11"
@@ -1175,7 +1149,6 @@ exports[`<Monthpicker /> event handling:  opens the overlay when clicking on the
                 </div>
               </styled.div>
               <styled.div
-                focussed={false}
                 hoverColor="#d3d3d330"
                 index={11}
                 key="M12"
@@ -1201,148 +1174,6 @@ exports[`<Monthpicker /> event handling:  opens the overlay when clicking on the
 </MonthPicker>
 `;
 
-exports[`<Monthpicker /> event handling:  sets the focussed date to 1 month earlier when hitting ArrowLeft 1`] = `
-.c0 {
-  cursor: pointer;
-  border: 1px solid #27718c;
-  background-color: #d3d3d330;
-  padding: 12px 0;
-  -webkit-transition: background-color .1s,color .1s;
-  transition: background-color .1s,color .1s;
-  font-size: 14px;
-  background-color: white;
-  color: #27718c;
-  height: 42px;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  -webkit-flex: 0 0 33.33%;
-  -ms-flex: 0 0 33.33%;
-  flex: 0 0 33.33%;
-}
-
-.c0:hover {
-  background-color: #d3d3d330;
-}
-
-.c0:focus {
-  outline: none;
-}
-
-.c0:nth-child(3n) {
-  border-right: 1px solid white;
-}
-
-.c0:nth-child(3n+1) {
-  border-left: 1px solid white;
-}
-
-.c0:nth-last-child(-n+3) {
-  border-bottom: 1px solid white;
-}
-
-<styled.div
-  focussed={true}
-  hoverColor="#d3d3d330"
-  index={0}
-  key="M01"
-  onClick={[Function]}
-  primaryColor="#27718c"
-  secondaryColor="white"
-  selected={false}
->
-  <div
-    className="c0"
-    onClick={[Function]}
-    selected={false}
-  >
-    M01
-  </div>
-</styled.div>
-`;
-
-exports[`<Monthpicker /> event handling:  sets the focussed date to 1 month later when hitting ArrowRight 1`] = `
-.c0 {
-  cursor: pointer;
-  border: 1px solid #27718c;
-  background-color: #d3d3d330;
-  padding: 12px 0;
-  -webkit-transition: background-color .1s,color .1s;
-  transition: background-color .1s,color .1s;
-  font-size: 14px;
-  background-color: white;
-  color: #27718c;
-  height: 42px;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  -webkit-flex: 0 0 33.33%;
-  -ms-flex: 0 0 33.33%;
-  flex: 0 0 33.33%;
-}
-
-.c0:hover {
-  background-color: #d3d3d330;
-}
-
-.c0:focus {
-  outline: none;
-}
-
-.c0:nth-child(3n) {
-  border-right: 1px solid white;
-}
-
-.c0:nth-child(3n+1) {
-  border-left: 1px solid white;
-}
-
-.c0:nth-last-child(-n+3) {
-  border-bottom: 1px solid white;
-}
-
-<styled.div
-  focussed={true}
-  hoverColor="#d3d3d330"
-  index={1}
-  key="M02"
-  onClick={[Function]}
-  primaryColor="#27718c"
-  secondaryColor="white"
-  selected={false}
->
-  <div
-    className="c0"
-    onClick={[Function]}
-    selected={false}
-  >
-    M02
-  </div>
-</styled.div>
-`;
-
-exports[`<Monthpicker /> event handling:  sets the focussed date to 3 month earlier when hitting ArrowUp 1`] = `null`;
-
-exports[`<Monthpicker /> event handling:  sets the focussed date to 3 month later when hitting ArrowDown 1`] = `null`;
-
 exports[`<Monthpicker /> renders its children 1`] = `
 <styled.div
   innerRef={[Function]}
@@ -1355,176 +1186,6 @@ exports[`<Monthpicker /> renders its children 1`] = `
     Child
   </div>
 </styled.div>
-`;
-
-exports[`<Monthpicker /> with allowedYears prop set to an array allows selecting years in the allowedYears array 1`] = `
-.c0 {
-  -webkit-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
-  user-select: none;
-}
-
-<styled.span>
-  <span
-    className="c0"
-  >
-    2017
-  </span>
-</styled.span>
-`;
-
-exports[`<Monthpicker /> with allowedYears prop set to an array does not allow selecting years not in the allowedYears array 1`] = `
-.c0 {
-  -webkit-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
-  user-select: none;
-}
-
-<styled.span>
-  <span
-    className="c0"
-  >
-    2018
-  </span>
-</styled.span>
-`;
-
-exports[`<Monthpicker /> with allowedYears prop set to an array goes to the correct year with an unsorted array 1`] = `
-.c0 {
-  -webkit-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
-  user-select: none;
-}
-
-<styled.span>
-  <span
-    className="c0"
-  >
-    2016
-  </span>
-</styled.span>
-`;
-
-exports[`<Monthpicker /> with allowedYears prop set to an array goes to the correct year with an unsorted array 2`] = `
-.c0 {
-  -webkit-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
-  user-select: none;
-}
-
-<styled.span>
-  <span
-    className="c0"
-  >
-    2020
-  </span>
-</styled.span>
-`;
-
-exports[`<Monthpicker /> with allowedYears prop set to an array goes to the next allowed year when clicking the next button 1`] = `
-.c0 {
-  -webkit-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
-  user-select: none;
-}
-
-<styled.span>
-  <span
-    className="c0"
-  >
-    2020
-  </span>
-</styled.span>
-`;
-
-exports[`<Monthpicker /> with allowedYears prop set to an array goes to the previous allowed year when clicking the previous button 1`] = `
-.c0 {
-  -webkit-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
-  user-select: none;
-}
-
-<styled.span>
-  <span
-    className="c0"
-  >
-    2016
-  </span>
-</styled.span>
-`;
-
-exports[`<Monthpicker /> with allowedYears prop set to an object does allow values after the after key 1`] = `
-.c0 {
-  -webkit-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
-  user-select: none;
-}
-
-<styled.span>
-  <span
-    className="c0"
-  >
-    2019
-  </span>
-</styled.span>
-`;
-
-exports[`<Monthpicker /> with allowedYears prop set to an object does allow values before the before key 1`] = `
-.c0 {
-  -webkit-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
-  user-select: none;
-}
-
-<styled.span>
-  <span
-    className="c0"
-  >
-    2017
-  </span>
-</styled.span>
-`;
-
-exports[`<Monthpicker /> with allowedYears prop set to an object does not allow values after the before key 1`] = `
-.c0 {
-  -webkit-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
-  user-select: none;
-}
-
-<styled.span>
-  <span
-    className="c0"
-  >
-    2018
-  </span>
-</styled.span>
-`;
-
-exports[`<Monthpicker /> with allowedYears prop set to an object does not allow values before the after key 1`] = `
-.c0 {
-  -webkit-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
-  user-select: none;
-}
-
-<styled.span>
-  <span
-    className="c0"
-  >
-    2018
-  </span>
-</styled.span>
 `;
 
 exports[`<Monthpicker /> works with different locales 1`] = `
@@ -1744,7 +1405,6 @@ exports[`<Monthpicker /> works with different locales 1`] = `
 
 <MonthPicker
   hoverColor="#d3d3d330"
-  initialYear={2018}
   locale="en"
   month={1}
   onChange={[MockFunction]}
@@ -1882,7 +1542,6 @@ exports[`<Monthpicker /> works with different locales 1`] = `
               className="c7"
             >
               <styled.div
-                focussed={true}
                 hoverColor="#d3d3d330"
                 index={0}
                 key="Jan"
@@ -1900,7 +1559,6 @@ exports[`<Monthpicker /> works with different locales 1`] = `
                 </div>
               </styled.div>
               <styled.div
-                focussed={false}
                 hoverColor="#d3d3d330"
                 index={1}
                 key="Feb"
@@ -1918,7 +1576,6 @@ exports[`<Monthpicker /> works with different locales 1`] = `
                 </div>
               </styled.div>
               <styled.div
-                focussed={false}
                 hoverColor="#d3d3d330"
                 index={2}
                 key="Mar"
@@ -1936,7 +1593,6 @@ exports[`<Monthpicker /> works with different locales 1`] = `
                 </div>
               </styled.div>
               <styled.div
-                focussed={false}
                 hoverColor="#d3d3d330"
                 index={3}
                 key="Apr"
@@ -1954,7 +1610,6 @@ exports[`<Monthpicker /> works with different locales 1`] = `
                 </div>
               </styled.div>
               <styled.div
-                focussed={false}
                 hoverColor="#d3d3d330"
                 index={4}
                 key="May"
@@ -1972,7 +1627,6 @@ exports[`<Monthpicker /> works with different locales 1`] = `
                 </div>
               </styled.div>
               <styled.div
-                focussed={false}
                 hoverColor="#d3d3d330"
                 index={5}
                 key="Jun"
@@ -1990,7 +1644,6 @@ exports[`<Monthpicker /> works with different locales 1`] = `
                 </div>
               </styled.div>
               <styled.div
-                focussed={false}
                 hoverColor="#d3d3d330"
                 index={6}
                 key="Jul"
@@ -2008,7 +1661,6 @@ exports[`<Monthpicker /> works with different locales 1`] = `
                 </div>
               </styled.div>
               <styled.div
-                focussed={false}
                 hoverColor="#d3d3d330"
                 index={7}
                 key="Aug"
@@ -2026,7 +1678,6 @@ exports[`<Monthpicker /> works with different locales 1`] = `
                 </div>
               </styled.div>
               <styled.div
-                focussed={false}
                 hoverColor="#d3d3d330"
                 index={8}
                 key="Sep"
@@ -2044,7 +1695,6 @@ exports[`<Monthpicker /> works with different locales 1`] = `
                 </div>
               </styled.div>
               <styled.div
-                focussed={false}
                 hoverColor="#d3d3d330"
                 index={9}
                 key="Oct"
@@ -2062,7 +1712,6 @@ exports[`<Monthpicker /> works with different locales 1`] = `
                 </div>
               </styled.div>
               <styled.div
-                focussed={false}
                 hoverColor="#d3d3d330"
                 index={10}
                 key="Nov"
@@ -2080,7 +1729,6 @@ exports[`<Monthpicker /> works with different locales 1`] = `
                 </div>
               </styled.div>
               <styled.div
-                focussed={false}
                 hoverColor="#d3d3d330"
                 index={11}
                 key="Dec"


### PR DESCRIPTION
This PR removes the whole focussing feature, so the monthpicker is fully controlled. Everytime you press an arrow key or change the year `onChange` is called.