### PR TITLE
Fix rollup warning messages

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -14,11 +14,23 @@ export default {
       file: 'dist/monthpicker.umd.js',
       name: 'monthpicker',
       format: 'umd',
+      globals: {
+        react: "React",
+        "prop-types": "PropTypes",
+        "styled-components": "styled",
+        "date-fns" :"dateFns"
+      }
     },
     {
       file: 'dist/monthpicker.es.js',
       name: 'monthpicker',
       format: 'es',
+      globals: {
+        react: "React",
+        "prop-types": "PropTypes",
+        "styled-components": "styled",
+        "date-fns" :"dateFns"
+      }
     }
   ],
   plugins: [


### PR DESCRIPTION
Fixes warnings when using `yarn compile`.

Before:
<img width="668" alt="Bildschirmfoto 2022-03-15 um 11 14 24" src="https://user-images.githubusercontent.com/53489780/158356076-e4720de7-3c6a-4e6b-ad82-0d4288a1a922.png">

After:
<img width="533" alt="Bildschirmfoto 2022-03-15 um 11 14 06" src="https://user-images.githubusercontent.com/53489780/158356030-26979dc7-82a6-429e-9295-0c0ed9ded967.png">
